### PR TITLE
Fix X, cleanup to allow easier symbol additions.

### DIFF
--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -27,6 +27,8 @@ chrome.extension.sendMessage({}, function(response) {
 			}
 		}
 		
+		//The key (for example, 'black' or 'red') should be the name of the <NAME>.gif we're trying to access.
+		//The key's value (for example, 'B' or 'R') should be the value of the old image, like 'Symbol_B_mana.gif'
 		var symbols = {
 			black: "B",
 			red: "R",

--- a/chrome/src/inject/inject.js
+++ b/chrome/src/inject/inject.js
@@ -35,12 +35,10 @@ chrome.extension.sendMessage({}, function(response) {
 			blue: "U",
 			tap: "T",
 			x: "X"
-		}
+		};
 		
-		for (var symbol in symbols){
-		
-			replaceWithCorrectUrl(getAll(getBaseXPathErrorUrl(symbols[symbol])), symbol);
-		
+		for (var type in symbols){
+			replaceWithCorrectUrl(getAll(getBaseXPathErrorUrl(symbols[type])), type);
 		}
 
 		for(var i = 0;i<21;i++) {


### PR DESCRIPTION
The name of the key in symbols should be the string name of the target gif (example, black.gif), whereas its value should be the string of the old naming pattern.